### PR TITLE
Improve quiz UI layout and clarity

### DIFF
--- a/src/components/CategoryList.tsx
+++ b/src/components/CategoryList.tsx
@@ -19,7 +19,6 @@ function CategoryList({
 
   const handleSelectChange = (e) => {
     const value = e.target.value || null;
-    console.log(value);
     onSelectionChange?.(value);
   };
 

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,13 +1,14 @@
 .header {
-  padding: 2rem 4rem;
+  padding: 1.5rem 3rem;
   margin-bottom: 20px;
-  height: 20vh;
+  min-height: 120px;
   background-color: #1a1449 !important;
   color: #fec82f;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
 }
 
 .header-brand {
@@ -19,6 +20,7 @@
 .header-nav {
   display: flex;
   gap: 20px;
+  flex-wrap: wrap;
 }
 
 .nav-link {
@@ -40,7 +42,8 @@
 }
 
 .header-logo {
-  height: auto;
+  max-height: 48px;
+  width: auto;
 }
 
 .header-divider {

--- a/src/components/QuizContainer.css
+++ b/src/components/QuizContainer.css
@@ -1,6 +1,19 @@
 .quiz-container {
   max-width: 700px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.quiz-timer {
+  align-self: flex-end;
+  background: rgba(26, 20, 73, 0.08);
+  color: #1a1449;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
 }
 
 .quiz-footer {
@@ -16,6 +29,7 @@
 
 .progress {
   color: #666;
+  font-weight: 600;
 }
 
 .submit-btn {
@@ -26,11 +40,13 @@
   border-radius: 4px;
   font-size: 16px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
 .submit-btn:hover:not(:disabled) {
   background-color: #45a049;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 16px rgba(76, 175, 80, 0.25);
 }
 
 .submit-btn:disabled {

--- a/src/components/QuizContainer.tsx
+++ b/src/components/QuizContainer.tsx
@@ -93,7 +93,11 @@ function QuizContainer() {
 
   return (
     <div className="quiz-container">
-      {settings.useTimeLimit ? <span>{timeLeft}</span> : null}
+      {settings.useTimeLimit ? (
+        <div className="quiz-timer" aria-live="polite">
+          ⏱️ Zbývá: {timeLeft}s
+        </div>
+      ) : null}
 
       <QuizSettings
         showRefresh={true}

--- a/src/components/QuizQuestion.css
+++ b/src/components/QuizQuestion.css
@@ -25,11 +25,23 @@
   border: 1px solid #ddd;
   border-radius: 4px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
 }
 
 .option:hover {
   background-color: #f0f0f0;
+}
+
+.option.selected {
+  background-color: rgba(76, 175, 80, 0.12);
+  border-color: #4caf50;
+  box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.15);
+}
+
+.option input[type="radio"]:focus-visible + .option-text {
+  outline: 2px solid rgba(26, 20, 73, 0.35);
+  outline-offset: 4px;
+  border-radius: 4px;
 }
 
 .option input[type="radio"] {

--- a/src/components/QuizQuestion.tsx
+++ b/src/components/QuizQuestion.tsx
@@ -21,7 +21,10 @@ function QuizQuestion({
       </h3>
       <div className="options">
         {question.options.map((option, index) => (
-          <label key={index} className="option">
+          <label
+            key={index}
+            className={`option ${selectedAnswer === index ? "selected" : ""}`}
+          >
             <input
               type="radio"
               name={`question-${questionNumber}`}

--- a/src/components/QuizSettings.css
+++ b/src/components/QuizSettings.css
@@ -6,15 +6,17 @@
   padding: 16px;
   background: white;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 10px 24px rgba(26, 20, 73, 0.08);
   margin-bottom: 20px;
 }
 
-.quiz-settings label {
+.quiz-settings .field-label {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
   color: #333;
+  font-weight: 600;
 }
 
 .quiz-settings select,
@@ -22,12 +24,24 @@
   padding: 8px 12px;
   border: 1px solid #ddd;
   border-radius: 4px;
+  width: 100%;
 }
 
 .quiz-settings input[type="number"] {
-  width: 70px;
+  max-width: 120px;
 }
 
 .quiz-settings .row {
   padding: 0.4rem;
+}
+
+.quiz-settings .form-control:focus,
+.quiz-settings select:focus {
+  border-color: #1a1449;
+  box-shadow: 0 0 0 2px rgba(26, 20, 73, 0.15);
+  outline: none;
+}
+
+.quiz-settings .btn {
+  min-width: 140px;
 }

--- a/src/components/QuizSettings.tsx
+++ b/src/components/QuizSettings.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import type { KeyboardEvent } from "react";
 import { getCategoriesWithCount } from "../services/questionService";
 import { useQuizSettings } from "../context/QuizContext";
 import "./QuizSettings.css";
@@ -29,9 +30,10 @@ function QuizSettings({
   const [inputName, setInputName] = useState(settings.name);
   const [errors, setErrors] = useState({ name: "", email: "" });
 
-  const validateEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  const validateEmail = (email: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
-  const validateField = (field, val) => {
+  const validateField = (field: string, val: string) => {
     if (!val) return "Povinné pole";
     if (field === "name" && val.length < 2) return "Min. 2 znaky";
     if (field === "email" && !validateEmail(val)) return "Neplatný email";
@@ -49,14 +51,13 @@ function QuizSettings({
     onValidationChange?.(hasError || notFilled);
   }, []);
 
-  const handleMaxQuestionsKeyDown = (e) => {
+  const handleMaxQuestionsKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       updateSettings({ questionCount: inputMaxQuestions });
     }
   };
 
-  const handleInputMaxQuestions = (val) => {
-    console.log("green ", val);
+  const handleInputMaxQuestions = (val: number) => {
     setInputMaxQuestions(val);
     updateSettings({ questionCount: val });
   };
@@ -66,7 +67,7 @@ function QuizSettings({
     if (onRefresh) onRefresh();
   };
 
-  const handleInput = (field, val) => {
+  const handleInput = (field: "name" | "email", val: string) => {
     if (field !== "name" && field !== "email") return;
 
     const newError = validateField(field, val);
@@ -84,7 +85,7 @@ function QuizSettings({
     onValidationChange?.(hasError || notFilled);
   };
 
-  const handleCategorySelection = (selected) => {
+  const handleCategorySelection = (selected: string | string[]) => {
     if (Array.isArray(selected)) {
       updateSettings({ selectedCategories: selected });
     } else {
@@ -98,27 +99,29 @@ function QuizSettings({
         {showNamePrompt && (
           <div className="row">
             <div className="col">
-              <label>
-                Name:
+              <label className="field-label">
+                Jméno
                 <input
                   type="text"
                   value={inputName}
                   onChange={(e) => handleInput("name", e.target.value)}
                   className="form-control"
-                  />
+                  placeholder="Např. Jana Nováková"
+                />
                 {errors.name && (
                   <span className="text-danger small">{errors.name}</span>
                 )}
               </label>
             </div>
             <div className="col">
-              <label>
-                Email:
+              <label className="field-label">
+                Email
                 <input
                   type="email"
                   value={inputEmail}
                   onChange={(e) => handleInput("email", e.target.value)}
                   className="form-control"
+                  placeholder="jmeno@firma.cz"
                 />
                 {errors.email && (
                   <span className="text-danger small">{errors.email}</span>
@@ -130,7 +133,7 @@ function QuizSettings({
 
         <div className="row">
           <div className="col">
-            <label>Category:</label>
+            <label className="field-label">Kategorie</label>
             <CategoryList
               categories={categories}
               onSelectionChange={handleCategorySelection}
@@ -144,8 +147,8 @@ function QuizSettings({
           </div>
 
           <div className="col">
-            <label>
-              Max questions:
+            <label className="field-label">
+              Počet otázek
               <input
                 type="number"
                 value={inputMaxQuestions}

--- a/src/components/QuizSummary.css
+++ b/src/components/QuizSummary.css
@@ -5,7 +5,10 @@
   padding: 40px;
   text-align: center;
   border-radius: 12px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 12px 30px rgba(26, 20, 73, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .threshold-badge {
@@ -61,8 +64,11 @@
   border-radius: 4px;
   font-size: 16px;
   cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
 .reset-btn:hover {
   background-color: #0056b3;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 16px rgba(0, 123, 255, 0.25);
 }

--- a/src/components/SummaryList.css
+++ b/src/components/SummaryList.css
@@ -1,13 +1,17 @@
 .summary-list {
   margin-top: 20px;
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .user-info {
   background: #e7f1ff;
   border-radius: 8px;
-  padding: 15px;
+  padding: 20px;
   margin-bottom: 20px;
+  border: 1px solid rgba(26, 20, 73, 0.08);
 }
 
 .user-info h3 {
@@ -16,9 +20,8 @@
   font-size: 1rem;
 }
 
-.user-info p {
-  margin: 5px 0;
-  color: #333;
+.user-info strong {
+  color: #1a1449;
 }
 
 .summary-item {
@@ -26,6 +29,7 @@
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 15px;
+  border: 1px solid rgba(26, 20, 73, 0.06);
 }
 
 .summary-question {
@@ -50,6 +54,7 @@
   border-radius: 4px;
   color: #666;
   font-size: 0.9rem;
+  border: 1px solid transparent;
 }
 
 .summary-option.correct {

--- a/src/components/SummaryList.tsx
+++ b/src/components/SummaryList.tsx
@@ -5,20 +5,38 @@ import { sendResultsEmail } from "../services/emailService";
 
 function SummaryList({ questions, answers, score, total, passed }) {
   const { settings } = useQuizSettings();
-  const [emailStatus, setEmailStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+  const [emailStatus, setEmailStatus] = useState<
+    "idle" | "sending" | "sent" | "error"
+  >("idle");
 
   const handleSendEmail = async () => {
-    const success = await sendResultsEmail({name: settings.name, score: score, total, passed, to: settings.email, questions, answers, detailed: false});
-    const success2 = await sendResultsEmail({name: settings.name, score: score, total, passed, to: settings.emailForCopy, questions, answers, detailed: true});
-    setEmailStatus(success ? 'sent' : 'error');
-    console.log('email short form sent: ',success)
-    console.log('email detailed form sent: ',success2)
-  }
+    const success = await sendResultsEmail({
+      name: settings.name,
+      score,
+      total,
+      passed,
+      to: settings.email,
+      questions,
+      answers,
+      detailed: false,
+    });
+    await sendResultsEmail({
+      name: settings.name,
+      score,
+      total,
+      passed,
+      to: settings.emailForCopy,
+      questions,
+      answers,
+      detailed: true,
+    });
+    setEmailStatus(success ? "sent" : "error");
+  };
 
   return (
     <div className="summary-list">
       <div className="user-info">
-        <h2>Summary pro {settings.name}</h2>
+        <h2>Souhrn pro {settings.name}</h2>
         <div className="d-flex flex-column gap-2">
           <div>
             <strong>Email:</strong> {settings.email || "Neuvedeno"}
@@ -33,12 +51,15 @@ function SummaryList({ questions, answers, score, total, passed }) {
             <button
               className="toggle-btn"
               onClick={handleSendEmail}
-              disabled={emailStatus === 'sending' || !settings.email}
+              disabled={emailStatus === "sending" || !settings.email}
             >
-              {emailStatus === 'sending' ? 'Odesílám...' :
-              emailStatus === 'sent' ? 'Odesláno ✓' :
-              emailStatus === 'error' ? 'Chyba - zkusit znovu' :
-              'Odeslat email'}
+              {emailStatus === "sending"
+                ? "Odesílám..."
+                : emailStatus === "sent"
+                  ? "Odesláno ✓"
+                  : emailStatus === "error"
+                    ? "Chyba - zkusit znovu"
+                    : "Odeslat email"}
             </button>
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,9 @@ body {
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   min-height: 100vh;
-  color: #fff;
+  color: #1a1449;
+  background: #f5f5f9;
+  line-height: 1.6;
 }
 
 .quiz-header-filter {

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -1,6 +1,8 @@
 .home {
   text-align: center;
   padding: 40px 20px;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 .home h2 {
@@ -13,6 +15,38 @@
   margin-bottom: 32px;
 }
 
+.home-card {
+  background: white;
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 10px 30px rgba(26, 20, 73, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.home-card-header h3 {
+  color: #1a1449;
+  margin-bottom: 8px;
+  font-size: 1.25rem;
+}
+
+.home-card-header p {
+  margin-bottom: 0;
+}
+
+.home-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.home-hint {
+  color: #6c757d;
+  font-size: 0.9rem;
+}
+
 .start-btn {
   padding: 16px 32px;
   font-size: 1.1rem;
@@ -21,14 +55,18 @@
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
 .start-btn:hover {
   background-color: #45a049;
+  box-shadow: 0 10px 16px rgba(76, 175, 80, 0.25);
+  transform: translateY(-1px);
 }
 
 .start-btn:disabled {
   background-color: #cccccc;
   cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -14,22 +14,33 @@ function Home() {
   return (
     <div className="home">
       <h2>Vítejte v Java Developers Quiz</h2>
-      <p>Otestujte své znalosti z Java ekosystému.</p>
+      <p>Otestujte své znalosti z Java ekosystému a získejte rychlou zpětnou vazbu.</p>
 
-      <div className="d-flex justify-content-center">
-        <QuizSettings
-          showRefresh={false}
-          showNamePrompt={true}
-          onValidationChange={setHasErrors}
-        />
+      <div className="home-card">
+        <div className="home-card-header">
+          <h3>Nastavení quizu</h3>
+          <p>Zvolte oblast, počet otázek a vyplňte kontaktní údaje pro výsledky.</p>
+        </div>
+        <div className="d-flex justify-content-center">
+          <QuizSettings
+            showRefresh={false}
+            showNamePrompt={true}
+            onValidationChange={setHasErrors}
+          />
+        </div>
+        <div className="home-actions">
+          <button
+            className="start-btn"
+            onClick={handleStartQuiz}
+            disabled={hasErrors}
+          >
+            Spustit Quiz
+          </button>
+          <span className="home-hint">
+            Vyplňte jméno a email, aby bylo možné spustit quiz.
+          </span>
+        </div>
       </div>
-      <button
-        className="start-btn"
-        onClick={handleStartQuiz}
-        disabled={hasErrors}
-      >
-        Spustit Quiz
-      </button>
     </div>
   );
 }

--- a/src/pages/Results.css
+++ b/src/pages/Results.css
@@ -1,6 +1,8 @@
 .results-page {
   text-align: center;
   padding: 40px 20px;
+  max-width: 960px;
+  margin: 0 auto;
 }
 
 .results-page h2 {
@@ -20,8 +22,11 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
 .results-page .btn:hover {
   background-color: #45a049;
+  box-shadow: 0 10px 16px rgba(76, 175, 80, 0.25);
+  transform: translateY(-1px);
 }

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -8,7 +8,7 @@ import { useQuizSettings } from "../context/QuizContext";
 
 function Results() {
   const navigate = useNavigate();
-  const {settings} = useQuizSettings();
+  const { settings } = useQuizSettings();
   const [showDetails, setShowDetails] = useState(false);
 
   const saved = sessionStorage.getItem("quizResults");
@@ -27,11 +27,6 @@ function Results() {
   const { questions, answers, score } = JSON.parse(saved) as QuizResults;
   const total = questions.length;
   const minimalRequiredScore = Math.ceil(settings.thresholdForSuccess * total);
-  console.log('min: ', minimalRequiredScore)
-  console.log('min: ', settings.thresholdForSuccess)
-  console.log('min: ', total)
-  console.log(questions[0]?.category);
-
   return (
     <div className="results-page">
       <QuizSummary


### PR DESCRIPTION
### Motivation
- Make the quiz UI more welcoming and easier to use while keeping the existing color palette. 
- Improve affordances (selected answers, timer, CTA) so users understand state and next steps at a glance. 
- Polish result and summary screens for clearer feedback and remove debug noise. 

### Description
- Redesigned home layout into a compact setup card with clearer CTA and hint, including `src/pages/Home.tsx` and `src/pages/Home.css`. 
- Improved question affordances by adding a visible selected state and focus styling for options in `src/components/QuizQuestion.tsx` and `src/components/QuizQuestion.css`. 
- Added a pill-style live timer and adjusted quiz container layout and button styles in `src/components/QuizContainer.tsx` and `src/components/QuizContainer.css`. 
- Refined settings and form UX (placeholders, labels, focus styles, small TypeScript typings) in `src/components/QuizSettings.tsx` and `src/components/QuizSettings.css`. 
- Polished header, results, and summary styling, removed leftover debug logs, and unified button interactions across the app (`src/components/Header.css`, `src/pages/Results.tsx`, `src/pages/Results.css`, `src/components/SummaryList.*`, `src/components/QuizSummary.css`, `src/index.css`). 
- Minor cleanup: removed a stray `console.log` and improved some Czech copy for clarity. 

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, which succeeded. 
- Ran a Playwright script to load the home page and capture a screenshot (`artifacts/home-ui.png`) which completed successfully. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749538e7188327a9746221c59449f8)