### PR TITLE
Store quiz results history in localStorage and display on Results page

### DIFF
--- a/src/components/QuizContainer.tsx
+++ b/src/components/QuizContainer.tsx
@@ -7,6 +7,11 @@ import "./QuizContainer.css";
 import { getQuestions } from "../services/questionService";
 import { useQuizSettings } from "../context/QuizContext";
 import type { Question } from "../types";
+import {
+  addQuizHistoryEntry,
+  createHistoryEntry,
+  createSettingsSnapshot,
+} from "../utils/quizResults";
 
 const QUIZ_TIME = 10;
 
@@ -71,10 +76,20 @@ function QuizContainer() {
 
   const handleSubmit = () => {
     const score = calculateScore();
-    sessionStorage.setItem(
-      "quizResults",
-      JSON.stringify({ questions, answers, score }),
+    const settingsSnapshot = createSettingsSnapshot({
+      name: settings.name,
+      email: settings.email,
+      emailForCopy: settings.emailForCopy,
+      category: settings.category,
+      selectedCategories: settings.selectedCategories,
+      questionCount: settings.questionCount,
+      thresholdForSuccess: settings.thresholdForSuccess,
+    });
+    const entry = createHistoryEntry(
+      { questions, answers, score },
+      settingsSnapshot,
     );
+    addQuizHistoryEntry(entry);
     navigate("/results");
   };
 

--- a/src/pages/Results.css
+++ b/src/pages/Results.css
@@ -30,3 +30,50 @@
   box-shadow: 0 10px 20px rgba(47, 91, 255, 0.3);
   transform: translateY(-1px);
 }
+
+.results-history {
+  margin: 32px 0 24px;
+  text-align: left;
+}
+
+.results-history h3 {
+  margin-bottom: 16px;
+  color: var(--color-text);
+}
+
+.history-list {
+  display: grid;
+  gap: 12px;
+}
+
+.history-item {
+  border: 1px solid rgba(47, 91, 255, 0.2);
+  border-radius: 16px;
+  padding: 12px 16px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+
+.history-item:hover {
+  border-color: rgba(47, 91, 255, 0.5);
+  box-shadow: 0 8px 16px rgba(47, 91, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.history-item.active {
+  border-color: var(--color-primary);
+  box-shadow: 0 12px 20px rgba(47, 91, 255, 0.2);
+}
+
+.history-title {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.history-meta {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,18 +1,38 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import QuizSummary from "../components/QuizSummary";
 import SummaryList from "../components/SummaryList";
-import type { QuizResults } from "../types";
+import type { QuizHistoryEntry } from "../types";
 import "./Results.css";
 import { useQuizSettings } from "../context/QuizContext";
+import { createSettingsSnapshot, loadQuizHistory } from "../utils/quizResults";
 
 function Results() {
   const navigate = useNavigate();
   const { settings } = useQuizSettings();
   const [showDetails, setShowDetails] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const saved = sessionStorage.getItem("quizResults");
-  if (!saved) {
+  const settingsSnapshot = useMemo(
+    () =>
+      createSettingsSnapshot({
+        name: settings.name,
+        email: settings.email,
+        emailForCopy: settings.emailForCopy,
+        category: settings.category,
+        selectedCategories: settings.selectedCategories,
+        questionCount: settings.questionCount,
+        thresholdForSuccess: settings.thresholdForSuccess,
+      }),
+    [settings],
+  );
+
+  const history = useMemo(
+    () => loadQuizHistory(settingsSnapshot),
+    [settingsSnapshot],
+  );
+
+  if (history.length === 0) {
     return (
       <div className="results-page">
         <h2>Výsledky</h2>
@@ -24,9 +44,14 @@ function Results() {
     );
   }
 
-  const { questions, answers, score } = JSON.parse(saved) as QuizResults;
+  const selectedEntry =
+    history.find((entry) => entry.id === selectedId) ?? history[0];
+  const { questions, answers, score, settingsSnapshot: selectedSettings } =
+    selectedEntry;
   const total = questions.length;
-  const minimalRequiredScore = Math.ceil(settings.thresholdForSuccess * total);
+  const minimalRequiredScore = Math.ceil(
+    selectedSettings.thresholdForSuccess * total,
+  );
   return (
     <div className="results-page">
       <QuizSummary
@@ -36,6 +61,37 @@ function Results() {
         onReset={() => navigate("/quiz")}
         minimalRequiredScore={minimalRequiredScore}
       />
+
+      <div className="results-history">
+        <h3>Historie výsledků</h3>
+        <div className="history-list">
+          {history.map((entry) => {
+            const entryTotal = entry.questions.length;
+            const entryMinimalScore = Math.ceil(
+              entry.settingsSnapshot.thresholdForSuccess * entryTotal,
+            );
+            const isActive = entry.id === selectedEntry.id;
+            return (
+              <button
+                key={entry.id}
+                className={`history-item ${isActive ? "active" : ""}`}
+                onClick={() => {
+                  setSelectedId(entry.id);
+                  setShowDetails(false);
+                }}
+              >
+                <div className="history-title">
+                  {new Date(entry.createdAt).toLocaleString("cs-CZ")}
+                </div>
+                <div className="history-meta">
+                  Skóre {entry.score}/{entryTotal} • Minimum{" "}
+                  {entryMinimalScore}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
 
       <div className="summary-details-toggle">
         <button
@@ -53,6 +109,9 @@ function Results() {
           score={score}
           total={total}
           passed={score >= minimalRequiredScore}
+          userName={selectedSettings.name}
+          userEmail={selectedSettings.email}
+          emailForCopy={selectedSettings.emailForCopy}
         />
       )}
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,3 +17,19 @@ export interface QuizResults {
   answers: Record<number, number>;
   score: number;
 }
+
+export interface QuizSettingsSnapshot {
+  name: string | null;
+  email: string | null;
+  emailForCopy: string | null;
+  category: string | null;
+  selectedCategories: string[];
+  questionCount: number;
+  thresholdForSuccess: number;
+}
+
+export interface QuizHistoryEntry extends QuizResults {
+  id: string;
+  createdAt: string;
+  settingsSnapshot: QuizSettingsSnapshot;
+}

--- a/src/utils/quizResults.ts
+++ b/src/utils/quizResults.ts
@@ -1,0 +1,94 @@
+import type { QuizHistoryEntry, QuizResults, QuizSettingsSnapshot } from "../types";
+
+const HISTORY_STORAGE_KEY = "quizResultsHistory";
+const LEGACY_STORAGE_KEY = "quizResults";
+
+const createId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+export const createSettingsSnapshot = (
+  settings: Partial<QuizSettingsSnapshot>,
+): QuizSettingsSnapshot => ({
+  name: settings.name ?? null,
+  email: settings.email ?? null,
+  emailForCopy: settings.emailForCopy ?? null,
+  category: settings.category ?? null,
+  selectedCategories: settings.selectedCategories ?? [],
+  questionCount: settings.questionCount ?? 0,
+  thresholdForSuccess: settings.thresholdForSuccess ?? 0,
+});
+
+export const createHistoryEntry = (
+  results: QuizResults,
+  settingsSnapshot: QuizSettingsSnapshot,
+): QuizHistoryEntry => ({
+  id: createId(),
+  createdAt: new Date().toISOString(),
+  settingsSnapshot,
+  ...results,
+});
+
+export const loadQuizHistory = (
+  fallbackSettingsSnapshot?: QuizSettingsSnapshot,
+): QuizHistoryEntry[] => {
+  if (typeof localStorage === "undefined") {
+    return [];
+  }
+
+  try {
+    const stored = localStorage.getItem(HISTORY_STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored) as QuizHistoryEntry[];
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  if (typeof sessionStorage === "undefined") {
+    return [];
+  }
+
+  const legacy = sessionStorage.getItem(LEGACY_STORAGE_KEY);
+  if (!legacy) {
+    return [];
+  }
+
+  try {
+    const parsedLegacy = JSON.parse(legacy) as QuizResults;
+    if (!fallbackSettingsSnapshot) {
+      return [];
+    }
+    const migratedEntry = createHistoryEntry(
+      parsedLegacy,
+      fallbackSettingsSnapshot,
+    );
+    const migrated = [migratedEntry];
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(migrated));
+    return migrated;
+  } catch {
+    return [];
+  }
+};
+
+export const saveQuizHistory = (history: QuizHistoryEntry[]) => {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+  localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
+};
+
+export const addQuizHistoryEntry = (
+  entry: QuizHistoryEntry,
+): QuizHistoryEntry[] => {
+  const history = loadQuizHistory();
+  const next = [entry, ...history];
+  saveQuizHistory(next);
+  return next;
+};


### PR DESCRIPTION
### Motivation
- Persist all quiz submissions so users can view historical results across sessions by saving them to `localStorage` instead of only `sessionStorage`.
- Provide a migration path for the previous single-run `sessionStorage` result into the new history storage.
- Allow the Results page to present selectable past attempts and reuse stored settings for correct pass/fail thresholds and email sending.

### Description
- Add new utility module `src/utils/quizResults.ts` with `createSettingsSnapshot`, `createHistoryEntry`, `loadQuizHistory`, `saveQuizHistory`, and `addQuizHistoryEntry` to manage history in `localStorage` and migrate legacy `sessionStorage` entries.
- Extend types in `src/types.ts` with `QuizSettingsSnapshot` and `QuizHistoryEntry` to model stored history entries.
- When a quiz is submitted, create a settings snapshot and history entry and persist it via `addQuizHistoryEntry` in `src/components/QuizContainer.tsx` instead of writing a single `sessionStorage` result.
- Update `src/pages/Results.tsx` to load history via `loadQuizHistory`, present a selectable history list, and compute pass thresholds from the stored settings snapshot; pass user info to `SummaryList`.
- Update `src/components/SummaryList.tsx` to accept `userName`, `userEmail`, and `emailForCopy`, and to send emails to the stored addresses (with safety checks), and add styling for the history UI in `src/pages/Results.css`.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported the app as ready on `http://localhost:4173/` (success).
- Ran a Playwright script that injected mock history into `localStorage`, navigated to `/results`, opened details, and produced a screenshot artifact at `artifacts/results-history.png` showing the new history UI (success).
- No unit tests were added; manual/automated smoke checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b99e9c9c8327b8a180848f084ccb)