### PR TITLE
Add quiz timing breakdown to results

### DIFF
--- a/src/components/QuizSummary.css
+++ b/src/components/QuizSummary.css
@@ -44,6 +44,13 @@
   margin-bottom: 16px;
 }
 
+.score-time {
+  font-size: 16px;
+  color: var(--color-muted);
+  margin-top: -8px;
+  margin-bottom: 8px;
+}
+
 .passed .score {
   color: var(--color-success);
 }

--- a/src/components/QuizSummary.tsx
+++ b/src/components/QuizSummary.tsx
@@ -1,6 +1,23 @@
 import "./QuizSummary.css";
+import { formatDuration } from "../utils/formatDuration";
 
-function QuizSummary({ score, total, passed, onReset, minimalRequiredScore }) {
+type QuizSummaryProps = {
+  score: number;
+  total: number;
+  passed: boolean;
+  onReset: () => void;
+  minimalRequiredScore: number;
+  totalDurationMs?: number;
+};
+
+function QuizSummary({
+  score,
+  total,
+  passed,
+  onReset,
+  minimalRequiredScore,
+  totalDurationMs,
+}: QuizSummaryProps) {
   return (
     <div className={`quiz-summary ${passed ? "passed" : "failed"}`}>
       <div className="text-end">
@@ -12,6 +29,7 @@ function QuizSummary({ score, total, passed, onReset, minimalRequiredScore }) {
       <div className="score">
         {score} / {total}
       </div>
+      <div className="score-time">Čas: {formatDuration(totalDurationMs)}</div>
       <p className="result-text">
         {passed ? "Congratulations! You passed!" : "Try again!"}
       </p>

--- a/src/components/SummaryList.css
+++ b/src/components/SummaryList.css
@@ -38,11 +38,22 @@
   font-weight: 600;
   margin-bottom: 10px;
   color: var(--color-text);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
 }
 
 .question-number {
   margin-right: 8px;
   color: var(--color-muted);
+}
+
+.question-time {
+  margin-left: auto;
+  font-weight: 600;
+  color: var(--color-muted);
+  font-size: 0.85rem;
 }
 
 .summary-options {

--- a/src/components/SummaryList.tsx
+++ b/src/components/SummaryList.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import "./SummaryList.css";
 import { sendResultsEmail } from "../services/emailService";
 import type { Question } from "../types";
+import { formatDuration } from "../utils/formatDuration";
 
 type SummaryListProps = {
   questions: Question[];
@@ -12,6 +13,8 @@ type SummaryListProps = {
   userName: string | null;
   userEmail: string | null;
   emailForCopy: string | null;
+  totalDurationMs?: number;
+  questionDurationsMs?: Record<number, number>;
 };
 
 function SummaryList({
@@ -23,6 +26,8 @@ function SummaryList({
   userName,
   userEmail,
   emailForCopy,
+  totalDurationMs,
+  questionDurationsMs,
 }: SummaryListProps) {
   const [emailStatus, setEmailStatus] = useState<
     "idle" | "sending" | "sent" | "error"
@@ -73,6 +78,9 @@ function SummaryList({
             <strong>Výsledek:</strong> {passed ? "✓" : "✗"}
           </div>
           <div>
+            <strong>Celkový čas:</strong> {formatDuration(totalDurationMs)}
+          </div>
+          <div>
             <button
               className="toggle-btn"
               onClick={handleSendEmail}
@@ -93,12 +101,16 @@ function SummaryList({
       {questions.map((q, qIndex) => {
         const userAnswer = answers[qIndex];
         const isCorrect = userAnswer === q.correctAnswer;
+        const questionDuration = questionDurationsMs?.[qIndex];
 
         return (
           <div key={qIndex} className="summary-item">
             <div className="summary-question">
               <span className="question-number">{qIndex + 1}.</span>
               {q.question}
+              <span className="question-time">
+                ⏱️ {formatDuration(questionDuration)}
+              </span>
             </div>
             <div className="summary-options">
               {q.options.map((option, oIndex) => {

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -6,6 +6,7 @@ import type { QuizHistoryEntry } from "../types";
 import "./Results.css";
 import { useQuizSettings } from "../context/QuizContext";
 import { createSettingsSnapshot, loadQuizHistory } from "../utils/quizResults";
+import { formatDuration } from "../utils/formatDuration";
 
 function Results() {
   const navigate = useNavigate();
@@ -46,8 +47,14 @@ function Results() {
 
   const selectedEntry =
     history.find((entry) => entry.id === selectedId) ?? history[0];
-  const { questions, answers, score, settingsSnapshot: selectedSettings } =
-    selectedEntry;
+  const {
+    questions,
+    answers,
+    score,
+    settingsSnapshot: selectedSettings,
+    totalDurationMs,
+    questionDurationsMs,
+  } = selectedEntry;
   const total = questions.length;
   const minimalRequiredScore = Math.ceil(
     selectedSettings.thresholdForSuccess * total,
@@ -60,6 +67,7 @@ function Results() {
         passed={score >= minimalRequiredScore}
         onReset={() => navigate("/quiz")}
         minimalRequiredScore={minimalRequiredScore}
+        totalDurationMs={totalDurationMs}
       />
 
       <div className="results-history">
@@ -85,7 +93,8 @@ function Results() {
                 </div>
                 <div className="history-meta">
                   Skóre {entry.score}/{entryTotal} • Minimum{" "}
-                  {entryMinimalScore}
+                  {entryMinimalScore} • Čas{" "}
+                  {formatDuration(entry.totalDurationMs)}
                 </div>
               </button>
             );
@@ -112,6 +121,8 @@ function Results() {
           userName={selectedSettings.name}
           userEmail={selectedSettings.email}
           emailForCopy={selectedSettings.emailForCopy}
+          totalDurationMs={totalDurationMs}
+          questionDurationsMs={questionDurationsMs}
         />
       )}
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface QuizResults {
   questions: Question[];
   answers: Record<number, number>;
   score: number;
+  totalDurationMs?: number;
+  questionDurationsMs?: Record<number, number>;
 }
 
 export interface QuizSettingsSnapshot {

--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,0 +1,17 @@
+export const formatDuration = (durationMs?: number | null): string => {
+  if (durationMs === null || durationMs === undefined || Number.isNaN(durationMs)) {
+    return "—";
+  }
+
+  const safeMs = Math.max(0, durationMs);
+  const totalSeconds = safeMs / 1000;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds - minutes * 60;
+  const secondsText = seconds.toFixed(1).replace(/\.0$/, "");
+
+  if (minutes > 0) {
+    return `${minutes}m ${secondsText}s`;
+  }
+
+  return `${secondsText}s`;
+};


### PR DESCRIPTION
### Motivation

- Capture how long the entire quiz took and how long the user spent on each question so the results page can report timing alongside score and history.

### Description

- Track quiz start time and per-question durations in `QuizContainer.tsx` and include `totalDurationMs` and `questionDurationsMs` in saved quiz results.
- Extend `QuizResults`/history types in `src/types.ts` to carry `totalDurationMs` and `questionDurationsMs`.
- Add a shared `formatDuration` helper in `src/utils/formatDuration.ts` to render durations human-readably.
- Surface timing in the UI by showing total time in `QuizSummary` and per-question times in `SummaryList`, and add small CSS tweaks to `SummaryList.css` and `QuizSummary.css` for layout.
- Pass timing values through `Results.tsx` so history list shows total time and the details pane shows per-question breakdown.

### Testing

- Started the dev server with `npm run dev`, which reported Vite ready and served the app successfully (local network address returned). 
- Ran Playwright-based smoke scripts: basic page screenshots (home and filled home) were produced, but full e2e quiz flow attempts timed out or the headless Chromium crashed (browser TargetClosedError / SIGSEGV), so the end-to-end quiz -> results verification did not complete. 
- No unit tests were added or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d7b902348327a2c3ddb7ea5f7558)