### PR TITLE
Consolidate email API into main server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "node server/index.js",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "format": "prettier --write"
+    "preview": "NODE_ENV=production node server/index.js",
+    "format": "prettier --write",
+    "start": "NODE_ENV=production node server/index.js"
   },
   "dependencies": {
     "bootstrap": "^5.3.8",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,200 @@
+import { createServer as createViteServer } from 'vite'
+import http from 'node:http'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readFile } from 'node:fs/promises'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const isProduction = process.env.NODE_ENV === 'production'
+const port = Number(process.env.PORT) || 5173
+
+const distPath = path.resolve(__dirname, '../dist')
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon'
+}
+
+const getContentType = (filePath) =>
+  mimeTypes[path.extname(filePath)] || 'application/octet-stream'
+
+const sendJson = (res, statusCode, payload) => {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(payload))
+}
+
+const readBody = async (req) => {
+  const chunks = []
+  for await (const chunk of req) {
+    chunks.push(chunk)
+  }
+
+  if (chunks.length === 0) {
+    return null
+  }
+
+  const data = Buffer.concat(chunks).toString('utf-8')
+  return JSON.parse(data)
+}
+
+const sendEmail = async ({
+  to,
+  name,
+  score,
+  total,
+  passed,
+  detailed = false,
+  questions,
+  answers
+}) => {
+  const percentage = Math.round((Number(score) / Number(total)) * 100)
+
+  let questionsText = ''
+  if (Array.isArray(questions) && answers) {
+    if (detailed) {
+      questionsText = questions
+        .map((question, index) => {
+          const userAnswerIndex = answers[index]
+          const isCorrect = userAnswerIndex === question.correctAnswer
+          const optionsText = question.options
+            .map((option, optionIndex) => {
+              const isUserAnswer = optionIndex === userAnswerIndex
+              const icon = isUserAnswer ? (isCorrect ? ' ✅' : ' ❌') : ''
+              return `   - ${option}${icon}`
+            })
+            .join('\n')
+          return `${index + 1}. ${question.question}\n${optionsText}`
+        })
+        .join('\n\n')
+    } else {
+      questionsText = questions
+        .map((question, index) => {
+          const userAnswerIndex = answers[index]
+          const isCorrect = userAnswerIndex === question.correctAnswer
+          return `${index + 1}. ${question.question} ${isCorrect ? '✅' : '❌'}`
+        })
+        .join('\n')
+    }
+  }
+
+  const subject = `TEST | Výsledky | Java Developer Quiz | ${name} - ${passed ? 'PROŠEL' : 'NEPROŠEL'} (${percentage}%)`
+  const text = `
+Ahoj ${name},
+
+TEST | Výsledky | Java Developer Quiz | ${name} - ${score}/${total} (${percentage}%)
+Status: ${passed ? 'PROŠEL ✅' : 'NEPROŠEL ❌'}
+
+${questionsText ? `Přehled odpovědí:\n\n${questionsText}` : ''}
+
+Děkujeme za účast!
+Prorocketeers
+  `.trim()
+
+  const fromEmail = process.env.SENDGRID_FROM_EMAIL || 'noreply@example.com'
+
+  const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.SENDGRID_API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      personalizations: [{ to: [{ email: to }], subject }],
+      from: { email: fromEmail },
+      content: [{ type: 'text/plain', value: text }]
+    })
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(errorText)
+  }
+}
+
+const requestHandler = (vite) => async (req, res) => {
+  const url = new URL(req.url || '/', 'http://localhost')
+
+  if (url.pathname === '/api/send-email') {
+    if (req.method === 'OPTIONS') {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({}))
+      return
+    }
+
+    if (req.method !== 'POST') {
+      sendJson(res, 405, { error: 'Method not allowed' })
+      return
+    }
+
+    try {
+      const body = await readBody(req)
+      const { to, name } = body || {}
+
+      if (!to || !name) {
+        sendJson(res, 400, { error: 'Missing required fields: to, name' })
+        return
+      }
+
+      if (!process.env.SENDGRID_API_KEY) {
+        sendJson(res, 500, { error: 'Missing SENDGRID_API_KEY configuration' })
+        return
+      }
+
+      await sendEmail(body)
+      sendJson(res, 200, { success: true, message: 'Email sent' })
+    } catch (error) {
+      console.error('SendGrid error:', error)
+      sendJson(res, 500, { error: 'Failed to send email' })
+    }
+
+    return
+  }
+
+  if (!isProduction && vite) {
+    vite.middlewares(req, res, () => {})
+    return
+  }
+
+  const filePath = url.pathname === '/' ? '/index.html' : url.pathname
+  const resolvedPath = path.join(distPath, filePath)
+
+  try {
+    const file = await readFile(resolvedPath)
+    res.writeHead(200, { 'Content-Type': getContentType(resolvedPath) })
+    res.end(file)
+  } catch (error) {
+    try {
+      const fallback = await readFile(path.join(distPath, 'index.html'))
+      res.writeHead(200, { 'Content-Type': 'text/html' })
+      res.end(fallback)
+    } catch (fallbackError) {
+      console.error('Failed to serve static file:', fallbackError)
+      res.writeHead(404)
+      res.end('Not found')
+    }
+  }
+}
+
+const startServer = async () => {
+  const vite = isProduction
+    ? null
+    : await createViteServer({
+        server: { middlewareMode: true },
+        appType: 'custom'
+      })
+
+  const server = http.createServer(requestHandler(vite))
+
+  server.listen(port, () => {
+    console.log(`Server running on http://localhost:${port}`)
+  })
+}
+
+startServer()

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1,6 +1,6 @@
 import type { Question } from '../types'
 
-const API_URL = 'http://localhost:3001'
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '')
 
 interface EmailData {
   to: string
@@ -15,7 +15,7 @@ interface EmailData {
 
 export async function sendResultsEmail(data: EmailData): Promise<boolean> {
   try {
-    const response = await fetch(`${API_URL}/api/send-email`, {
+    const response = await fetch(`${API_BASE_URL}/api/send-email`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)


### PR DESCRIPTION
### Motivation
- Unify the separate frontend and email API into a single app to simplify development and deployment and avoid cross-origin API calls. 
- Serve the Vite app and API from the same origin so the client can call `/api/send-email` directly. 
- Use a lightweight Node server that supports Vite dev middleware and a production static file fallback.

### Description
- Add `server/index.js` which starts an HTTP server that mounts Vite middleware in development, serves `dist` in production, and implements the `/api/send-email` endpoint that forwards to SendGrid using `SENDGRID_API_KEY` and `SENDGRID_FROM_EMAIL` environment variables. 
- Update `src/services/emailService.ts` to use `VITE_API_BASE_URL` (same-origin by default) and post to `/api/send-email` via the unified server. 
- Adjust `package.json` scripts so `dev`, `preview` and `start` run the unified `server/index.js` for dev and production flows.

### Testing
- Attempted to install `express` and `@sendgrid/mail` with `npm install express @sendgrid/mail`, but the install failed with an npm `403` error due to registry/access policy. 
- No automated test suite was executed after the changes. 
- The server implementation requires `SENDGRID_API_KEY` and `SENDGRID_FROM_EMAIL` environment variables to successfully send emails and should be validated in a runtime environment before production use.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ddb12c8c8327a8665d16e3811620)