### PR TITLE
Fix Vite dev server response

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -186,8 +186,7 @@ const startServer = async () => {
   const vite = isProduction
     ? null
     : await createViteServer({
-        server: { middlewareMode: true },
-        appType: 'custom'
+        server: { middlewareMode: true }
       })
 
   const server = http.createServer(requestHandler(vite))


### PR DESCRIPTION
### Motivation
- The Vite dev middleware was not serving the SPA entry HTML in development, causing the app to appear stuck loading, so the custom `appType` override was removed to restore normal middleware behavior.

### Description
- Remove the `appType: 'custom'` option passed to `createViteServer` and keep `server: { middlewareMode: true }` in `server/index.js`, so the dev server can serve `index.html` correctly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f284171083279ae026320cdda4a1)