### PR TITLE
Automate quiz result email sending and status tracking

### DIFF
--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,12 +1,17 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import QuizSummary from "../components/QuizSummary";
 import SummaryList from "../components/SummaryList";
 import type { QuizHistoryEntry } from "../types";
 import "./Results.css";
 import { useQuizSettings } from "../context/QuizContext";
-import { createSettingsSnapshot, loadQuizHistory } from "../utils/quizResults";
+import {
+  createSettingsSnapshot,
+  loadQuizHistory,
+  saveQuizHistory,
+} from "../utils/quizResults";
 import { formatDuration } from "../utils/formatDuration";
+import { sendResultsEmail } from "../services/emailService";
 
 function Results() {
   const navigate = useNavigate();
@@ -28,10 +33,13 @@ function Results() {
     [settings],
   );
 
-  const history = useMemo(
-    () => loadQuizHistory(settingsSnapshot),
-    [settingsSnapshot],
+  const [history, setHistory] = useState<QuizHistoryEntry[]>(() =>
+    loadQuizHistory(settingsSnapshot),
   );
+
+  useEffect(() => {
+    setHistory(loadQuizHistory(settingsSnapshot));
+  }, [settingsSnapshot]);
 
   if (history.length === 0) {
     return (
@@ -67,6 +75,84 @@ function Results() {
         : [...prev, entryId],
     );
   };
+
+  const handleEmailStatusChange = useCallback(
+    (entryId: string, status: QuizHistoryEntry["emailStatus"]) => {
+      setHistory((prev) => {
+        const next = prev.map((entry) =>
+          entry.id === entryId ? { ...entry, emailStatus: status } : entry,
+        );
+        saveQuizHistory(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!selectedEntry) {
+      return;
+    }
+    if (selectedEntry.emailStatus !== "idle") {
+      return;
+    }
+    const userEmail = selectedEntry.settingsSnapshot.email;
+    if (!userEmail) {
+      return;
+    }
+    let isCancelled = false;
+    const sendEmail = async () => {
+      handleEmailStatusChange(selectedEntry.id, "sending");
+      const resolvedName =
+        selectedEntry.settingsSnapshot.name || "Neznámý uživatel";
+      const primaryResult = await sendResultsEmail({
+        name: resolvedName,
+        score: selectedEntry.score,
+        total: selectedEntry.questions.length,
+        passed: selectedEntry.score >= minimalRequiredScore,
+        to: userEmail,
+        questions: selectedEntry.questions,
+        answers: selectedEntry.answers,
+        detailed: false,
+      });
+      let copySuccess = true;
+      if (selectedEntry.settingsSnapshot.emailForCopy) {
+        const copyResult = await sendResultsEmail({
+          name: resolvedName,
+          score: selectedEntry.score,
+          total: selectedEntry.questions.length,
+          passed: selectedEntry.score >= minimalRequiredScore,
+          to: selectedEntry.settingsSnapshot.emailForCopy,
+          questions: selectedEntry.questions,
+          answers: selectedEntry.answers,
+          detailed: true,
+        });
+        copySuccess = copyResult.success;
+      }
+      if (isCancelled) {
+        return;
+      }
+      handleEmailStatusChange(
+        selectedEntry.id,
+        primaryResult.success && copySuccess ? "sent" : "error",
+      );
+    };
+    void sendEmail();
+    return () => {
+      isCancelled = true;
+    };
+  }, [
+    handleEmailStatusChange,
+    minimalRequiredScore,
+    selectedEntry,
+    selectedEntry?.answers,
+    selectedEntry?.emailStatus,
+    selectedEntry?.questions,
+    selectedEntry?.score,
+    selectedEntry?.settingsSnapshot.email,
+    selectedEntry?.settingsSnapshot.emailForCopy,
+    selectedEntry?.settingsSnapshot.name,
+  ]);
 
   return (
     <div className="results-page">
@@ -128,6 +214,10 @@ function Results() {
                       userName={entry.settingsSnapshot.name}
                       userEmail={entry.settingsSnapshot.email}
                       emailForCopy={entry.settingsSnapshot.emailForCopy}
+                      emailStatus={entry.emailStatus ?? "idle"}
+                      onEmailStatusChange={(status) =>
+                        handleEmailStatusChange(entry.id, status)
+                      }
                       totalDurationMs={entry.totalDurationMs}
                       questionDurationsMs={entry.questionDurationsMs}
                     />

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,4 +34,5 @@ export interface QuizHistoryEntry extends QuizResults {
   id: string;
   createdAt: string;
   settingsSnapshot: QuizSettingsSnapshot;
+  emailStatus?: "idle" | "sending" | "sent" | "error";
 }

--- a/src/utils/quizResults.ts
+++ b/src/utils/quizResults.ts
@@ -29,6 +29,7 @@ export const createHistoryEntry = (
   id: createId(),
   createdAt: new Date().toISOString(),
   settingsSnapshot,
+  emailStatus: "idle",
   ...results,
 });
 
@@ -89,6 +90,18 @@ export const addQuizHistoryEntry = (
 ): QuizHistoryEntry[] => {
   const history = loadQuizHistory();
   const next = [entry, ...history];
+  saveQuizHistory(next);
+  return next;
+};
+
+export const updateQuizHistoryEntryEmailStatus = (
+  entryId: string,
+  emailStatus: QuizHistoryEntry["emailStatus"],
+): QuizHistoryEntry[] => {
+  const history = loadQuizHistory();
+  const next = history.map((entry) =>
+    entry.id === entryId ? { ...entry, emailStatus } : entry,
+  );
   saveQuizHistory(next);
   return next;
 };


### PR DESCRIPTION
### Motivation
- Users reported that result emails are not reliably sent and that the results panel does not show whether an email was delivered; the change implements automatic sending and visible status tracking.

### Description
- Add `emailStatus` to `QuizHistoryEntry` and initialize it to `"idle"` in `createHistoryEntry`, plus provide an updater in `src/utils/quizResults.ts` to persist status changes.
- Change the client email API (`src/services/emailService.ts`) to return a structured `EmailResponse`, robustly parse response bodies, and surface error messages instead of only boolean results.
- Surface email status and a send button in `SummaryList` and lift status management to the results page by passing `emailStatus` and `onEmailStatusChange` callbacks; the UI now shows a human-friendly email status label.
- In `Results` page, manage history in component state, persist updates with `saveQuizHistory`, and auto-send result emails for the selected/latest entry when its `emailStatus` is `idle`, updating the stored status to `sending`, `sent`, or `error` accordingly.

### Testing
- Started the dev server with `npm run dev` and the server ran successfully (server output shown as running). (succeeded)
- Ran an automated Playwright smoke script that populates `localStorage` with a sample history entry, navigates to `/results`, expands details and captures a screenshot artifact `artifacts/results-email-status.png` to verify the results panel shows the email status. (succeeded)
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697514945158832792fe87c9dc0e022b)