### PR TITLE
Add quiz settings toggle and two-column category layout

### DIFF
--- a/src/components/CategoryList.css
+++ b/src/components/CategoryList.css
@@ -1,6 +1,6 @@
 .category-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -75,6 +75,10 @@
 }
 
 @media (max-width: 768px) {
+  .category-list {
+    grid-template-columns: 1fr;
+  }
+
   .category-item {
     flex-direction: column;
     align-items: flex-start;

--- a/src/components/QuizContainer.css
+++ b/src/components/QuizContainer.css
@@ -28,6 +28,11 @@
   border: 1px solid var(--color-border);
 }
 
+.quiz-settings-toggle {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .progress {
   color: var(--color-muted);
   font-weight: 600;

--- a/src/components/QuizContainer.tsx
+++ b/src/components/QuizContainer.tsx
@@ -18,6 +18,7 @@ const QUIZ_TIME = 10;
 function QuizContainer() {
   const navigate = useNavigate();
   const { settings } = useQuizSettings();
+  const [showSettings, setShowSettings] = useState(false);
   const [questions, setQuestions] = useState<Question[]>([]);
   const [answers, setAnswers] = useState<Record<number, number>>({});
   const [questionDurationsMs, setQuestionDurationsMs] = useState<
@@ -134,11 +135,26 @@ function QuizContainer() {
         </div>
       ) : null}
 
-      <QuizSettings
-        showRefresh={true}
-        onRefresh={handleRefresh}
-        showNamePrompt={false}
-      />
+      <div className="quiz-settings-toggle">
+        <button
+          className="toggle-btn"
+          onClick={() => setShowSettings((prev) => !prev)}
+          aria-expanded={showSettings}
+          aria-controls="quiz-settings-panel"
+        >
+          {showSettings ? "Skrýt nastavení" : "Ukázat nastavení"}
+        </button>
+      </div>
+
+      {showSettings && (
+        <div id="quiz-settings-panel">
+          <QuizSettings
+            showRefresh={true}
+            onRefresh={handleRefresh}
+            showNamePrompt={false}
+          />
+        </div>
+      )}
 
       {questions.map((q, index) => (
         <QuizQuestion


### PR DESCRIPTION
### Motivation
- Provide a way to hide the settings panel when the quiz starts and allow the user to reveal it with a button, and improve category panel density by showing categories in two columns on larger screens.

### Description
- Add a show/hide toggle to the quiz view and keep the settings panel hidden by default by introducing `showSettings` state and conditional rendering of `QuizSettings` in `src/components/QuizContainer.tsx`.
- Add a right-aligned toggle control with accessible attributes (`aria-expanded`, `aria-controls`) and Czech labels `Ukázat nastavení` / `Skrýt nastavení` in `src/components/QuizContainer.tsx`.
- Align the toggle in the layout by adding `.quiz-settings-toggle` rules in `src/components/QuizContainer.css`.
- Change the multi-select category list from a single-column flex layout to a two-column responsive CSS grid in `src/components/CategoryList.css` with a mobile fallback to one column.

### Testing
- Started the dev server with `npm run dev` and confirmed the app served at the expected URL; this completed successfully.
- Ran a Playwright script that navigated to `http://localhost:5173/quiz`, clicked the `Ukázat nastavení` toggle and captured a screenshot at `artifacts/quiz-settings-toggle.png`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976072bfc308327b7875aa8e3d72f69)