### PR TITLE
Add Markdown ↔ JSON conversion script for quiz questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,31 @@ The React Compiler is not enabled on this template because of its impact on dev 
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Quiz otázky (Markdown ↔ JSON)
+
+Zdroj pravdy pro otázky může být Markdown soubor `questions.md` v kořeni projektu. Převod na JSON (a zpět) zajišťuje skript `scripts/questions-convert.js`.
+
+### Formát `questions.md`
+
+Použijte strukturu s kategoriemi (H2), otázkami (H3) a odpověďmi jako seznam s checkboxy:
+
+```md
+## Docker
+
+### Co je Docker a k čemu se používá?
+- [x] Docker je platforma pro vytváření, distribuci a spouštění kontejnerizovaných aplikací.
+- [ ] Docker je programovací jazyk pro webové aplikace.
+- [ ] Docker je databázový systém.
+```
+
+Právě jeden checkbox musí být označený jako správná odpověď (`[x]`).
+
+### Příkazy
+
+```bash
+npm run questions:to-json
+npm run questions:to-md
+```
+
+Výchozí cesty lze přepsat parametry `--input` a `--output`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "NODE_ENV=production node server/index.js",
     "format": "prettier --write",
-    "start": "NODE_ENV=production node server/index.js"
+    "start": "NODE_ENV=production node server/index.js",
+    "questions:to-json": "node scripts/questions-convert.js --to-json --input questions.md --output src/data/questions.json",
+    "questions:to-md": "node scripts/questions-convert.js --to-md --input src/data/questions.json --output questions.md"
   },
   "dependencies": {
     "bootstrap": "^5.3.8",

--- a/scripts/questions-convert.js
+++ b/scripts/questions-convert.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const parsedArgs = new Map();
+let mode = null;
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === "--to-json" || arg === "--to-md") {
+    mode = arg;
+    continue;
+  }
+  if (arg.startsWith("--")) {
+    const key = arg.slice(2);
+    const value = args[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    parsedArgs.set(key, value);
+    i += 1;
+  }
+}
+
+const resolvePath = (value, fallback) =>
+  path.resolve(process.cwd(), value ?? fallback);
+
+const inputPath = resolvePath(parsedArgs.get("input"), "questions.md");
+const outputPath = resolvePath(
+  parsedArgs.get("output"),
+  mode === "--to-md" ? "questions.md" : "src/data/questions.json"
+);
+
+const ensureDir = (filePath) => {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+};
+
+const parseMarkdown = (content) => {
+  const lines = content.split(/\r?\n/);
+  const questions = [];
+  let category = null;
+  let currentQuestion = null;
+  let options = [];
+  let correctAnswer = null;
+
+  const flushQuestion = () => {
+    if (!currentQuestion) {
+      return;
+    }
+    if (!category) {
+      throw new Error(`Missing category for question "${currentQuestion}"`);
+    }
+    if (options.length < 2) {
+      throw new Error(
+        `Question "${currentQuestion}" must have at least 2 options.`
+      );
+    }
+    if (correctAnswer === null) {
+      throw new Error(
+        `Question "${currentQuestion}" must mark exactly one correct answer.`
+      );
+    }
+    questions.push({
+      category,
+      question: currentQuestion,
+      options,
+      correctAnswer,
+    });
+    currentQuestion = null;
+    options = [];
+    correctAnswer = null;
+  };
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (trimmed.startsWith("## ")) {
+      flushQuestion();
+      category = trimmed.slice(3).trim();
+      return;
+    }
+    if (trimmed.startsWith("### ")) {
+      flushQuestion();
+      currentQuestion = trimmed.slice(4).trim();
+      return;
+    }
+
+    const match = trimmed.match(/^[-*]\s+\[( |x|X)\]\s+(.*)$/);
+    if (match) {
+      if (!currentQuestion) {
+        throw new Error(
+          `Answer found before question at line ${index + 1}: "${line}"`
+        );
+      }
+      const isCorrect = match[1].toLowerCase() === "x";
+      if (isCorrect) {
+        if (correctAnswer !== null) {
+          throw new Error(
+            `Multiple correct answers found for "${currentQuestion}".`
+          );
+        }
+        correctAnswer = options.length;
+      }
+      options.push(match[2].trim());
+      return;
+    }
+
+    throw new Error(
+      `Unrecognized line ${index + 1}: "${line}". Expected ## category, ### question, or list item.`
+    );
+  });
+
+  flushQuestion();
+  return questions;
+};
+
+const toMarkdown = (questions) => {
+  const groups = new Map();
+  questions.forEach((q) => {
+    if (!groups.has(q.category)) {
+      groups.set(q.category, []);
+    }
+    groups.get(q.category).push(q);
+  });
+
+  const lines = ["# Quiz otázky"];
+  for (const [categoryName, items] of groups) {
+    lines.push("", `## ${categoryName}`);
+    items.forEach((q) => {
+      lines.push("", `### ${q.question}`);
+      q.options.forEach((option, index) => {
+        const marker = index === q.correctAnswer ? "x" : " ";
+        lines.push(`- [${marker}] ${option}`);
+      });
+    });
+  }
+  return `${lines.join("\n")}\n`;
+};
+
+if (!mode) {
+  throw new Error("Missing mode. Use --to-json or --to-md.");
+}
+
+if (mode === "--to-json") {
+  const source = fs.readFileSync(inputPath, "utf8");
+  const questions = parseMarkdown(source);
+  ensureDir(outputPath);
+  fs.writeFileSync(outputPath, `${JSON.stringify(questions, null, 2)}\n`);
+  console.log(
+    `Converted ${questions.length} questions from ${inputPath} to ${outputPath}.`
+  );
+} else if (mode === "--to-md") {
+  const source = fs.readFileSync(inputPath, "utf8");
+  const questions = JSON.parse(source);
+  if (!Array.isArray(questions)) {
+    throw new Error("Expected JSON array of questions.");
+  }
+  ensureDir(outputPath);
+  fs.writeFileSync(outputPath, toMarkdown(questions));
+  console.log(
+    `Converted ${questions.length} questions from ${inputPath} to ${outputPath}.`
+  );
+} else {
+  throw new Error(`Unknown mode: ${mode}`);
+}


### PR DESCRIPTION
### Motivation

- Provide an easy, human-editable source of truth for quiz questions in a Markdown format so contributors can author questions without editing large JSON files. 
- Allow the repository to generate the `src/data/questions.json` consumed by the app from the Markdown source and to regenerate Markdown from JSON when needed.

### Description

- Add `scripts/questions-convert.js`, a Node.js CLI that converts between `questions.md` and `src/data/questions.json` using `--to-json` and `--to-md` modes and supports `--input`/`--output` overrides. 
- Add npm scripts `questions:to-json` and `questions:to-md` to `package.json` for one-step conversion commands (`npm run questions:to-json`, `npm run questions:to-md`).
- Document the `questions.md` format (H2 categories, H3 questions, `- [x]`/`- [ ]` options) and usage in `README.md` so maintainers know how to author and convert question data. 
- Keep the runtime behavior unchanged: the app still reads questions from `src/data/questions.json` (see `src/services/questionService.ts`), so using Markdown as the source of truth requires running the conversion script to produce that JSON.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763948e55483279d3f26adee78cf8c)