### PR TITLE
Add consent checkbox for emailing results

### DIFF
--- a/src/components/QuizSettings.css
+++ b/src/components/QuizSettings.css
@@ -20,6 +20,22 @@
   font-weight: 600;
 }
 
+.quiz-settings .consent-label {
+  margin-top: 12px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.quiz-settings .consent-label input[type="checkbox"] {
+  margin-top: 4px;
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-primary);
+}
+
 .quiz-settings select,
 .quiz-settings input {
   padding: 10px 12px;

--- a/src/components/QuizSettings.tsx
+++ b/src/components/QuizSettings.tsx
@@ -28,6 +28,9 @@ function QuizSettings({
   );
   const [inputEmail, setInputEmail] = useState(settings.email);
   const [inputName, setInputName] = useState(settings.name);
+  const [consentGiven, setConsentGiven] = useState(
+    settings.consentToEmailResults ?? false,
+  );
   const [errors, setErrors] = useState({ name: "", email: "" });
   const categoryQuestionCounts = settings.categoryQuestionCounts ?? {};
 
@@ -48,8 +51,9 @@ function QuizSettings({
     const emailError = validateField("email", settings.email);
     const hasError = !!nameError || !!emailError;
     const notFilled = !settings.name || !settings.email;
+    const consentMissing = !settings.consentToEmailResults;
 
-    onValidationChange?.(hasError || notFilled);
+    onValidationChange?.(hasError || notFilled || consentMissing);
   }, []);
 
   const handleMaxQuestionsKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -78,12 +82,28 @@ function QuizSettings({
     const currentName = field === "name" ? val : inputName;
     const currentEmail = field === "email" ? val : inputEmail;
     const notFilled = !currentName || !currentEmail;
+    const consentMissing = !consentGiven;
 
     const setters = { name: setInputName, email: setInputEmail };
     setters[field](val);
     updateSettings({ [field]: val });
 
-    onValidationChange?.(hasError || notFilled);
+    onValidationChange?.(hasError || notFilled || consentMissing);
+  };
+
+  const handleConsentChange = (checked: boolean) => {
+    setConsentGiven(checked);
+    updateSettings({ consentToEmailResults: checked });
+
+    if (!showNamePrompt) return;
+
+    const nameError = validateField("name", inputName);
+    const emailError = validateField("email", inputEmail);
+    const hasError = !!nameError || !!emailError;
+    const notFilled = !inputName || !inputEmail;
+    const consentMissing = !checked;
+
+    onValidationChange?.(hasError || notFilled || consentMissing);
   };
 
   const handleCategorySelection = (selected: string | string[]) => {
@@ -169,6 +189,17 @@ function QuizSettings({
                 {errors.email && (
                   <span className="text-danger small">{errors.email}</span>
                 )}
+              </label>
+            </div>
+            <div className="col-12">
+              <label className="consent-label">
+                <input
+                  type="checkbox"
+                  checked={consentGiven}
+                  onChange={(e) => handleConsentChange(e.target.checked)}
+                />
+                Souhlasím se zpracováním osobních údajů pouze za účelem
+                odeslání emailu s výsledky.
               </label>
             </div>
           </div>

--- a/src/context/QuizContext.tsx
+++ b/src/context/QuizContext.tsx
@@ -14,7 +14,8 @@ const SETTINGS_DEFAULT = {
   categoryQuestionCounts: {},
   multiSelect: true,
   thresholdForSuccess: 0.5,
-  emailForCopy: "peopleandculture@prorocketeers.com"
+  emailForCopy: "peopleandculture@prorocketeers.com",
+  consentToEmailResults: false,
 };
 
 const STORAGE_KEY = 'quizSettings';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,7 +37,7 @@ function Home() {
             Spustit Quiz
           </button>
           <span className="home-hint">
-            Vyplňte jméno a email, aby bylo možné spustit quiz.
+            Vyplňte jméno, email a potvrďte souhlas se zpracováním údajů.
           </span>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Require explicit user consent for processing personal data so results can be emailed to the user. 
- Persist the consent decision in quiz settings so it survives page reloads.

### Description
- Add `consentToEmailResults` to the default settings in `src/context/QuizContext.tsx` and persist it to session storage. 
- Add a consent checkbox and `handleConsentChange` logic in `src/components/QuizSettings.tsx`, wire the consent into the existing name/email validation and call `onValidationChange` when consent changes. 
- Add styles for the new checkbox in `src/components/QuizSettings.css` and update the hint on the home page in `src/pages/Home.tsx` to mention consent.

### Testing
- Started the dev server with `npm run dev`, which reported the app running on `http://localhost:5173`. 
- Attempted a Playwright screenshot to validate the UI, but the headless Chromium process crashed (`TargetClosedError`/SIGSEGV) and the screenshot failed. 
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764d2745508327ba5baaf551394cd9)