### PR TITLE
Localize quiz branding to Czech: "Kvíz pro softwareové inženýry"

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,7 @@ function Header() {
       <div className="header-brand">
         <img src={logo} alt="Prorocketeers" className="header-logo" />
         <span className="header-divider">|</span>
-        <h1 className="header-title">Java Developers Quiz</h1>
+        <h1 className="header-title">Kvíz pro softwareové inženýry</h1>
       </div>
       <nav className="header-nav">
         <NavLink

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,8 +13,11 @@ function Home() {
 
   return (
     <div className="home">
-      <h2>Vítejte v Java Developers Quiz</h2>
-      <p>Otestujte své znalosti z Java ekosystému a získejte rychlou zpětnou vazbu.</p>
+      <h2>Vítejte v kvízu pro softwareové inženýry</h2>
+      <p>
+        Otestujte své znalosti ze světa software engineeringu a získejte rychlou
+        zpětnou vazbu.
+      </p>
 
       <div className="home-card">
         <div className="home-card-header">


### PR DESCRIPTION
### Motivation
- Replace English/Java-specific UI copy with Czech phrasing and generalize the quiz branding to software engineering as requested.

### Description
- Updated the header title in `src/components/Header.tsx` to `Kvíz pro softwareové inženýry`.
- Updated the home page welcome headline and descriptive paragraph in `src/pages/Home.tsx` to match the Czech, software-engineering branding.
- This is a content-only change with no logic or behavior modifications.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the server ran successfully, then used Playwright to visit `http://localhost:5173/` and captured a screenshot `artifacts/kviz-pro-softwareove-inzenyry-home.png` which completed successfully.
- No unit or integration tests were changed for this content update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764e9f23208327960390abdd0f358c)